### PR TITLE
Feature/#5 지원서 정보 API 개발

### DIFF
--- a/src/main/java/org/mjulikelion/bagel/controller/ApplicationController.java
+++ b/src/main/java/org/mjulikelion/bagel/controller/ApplicationController.java
@@ -1,0 +1,29 @@
+package org.mjulikelion.bagel.controller;
+
+import org.mjulikelion.bagel.dto.response.ResponseDto;
+import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
+import org.mjulikelion.bagel.model.Part;
+import org.mjulikelion.bagel.service.application.ApplicationQueryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("application")
+public class ApplicationController {
+    private final ApplicationQueryService applicationQueryService;
+
+    @Autowired
+    public ApplicationController(ApplicationQueryService applicationQueryService) {
+        this.applicationQueryService = applicationQueryService;
+    }
+
+    @GetMapping("/{part}")
+    public ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(
+            @PathVariable("part") Part part) {
+        return this.applicationQueryService.getApplicationByPart(part);
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/dto/response/ResponseDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/response/ResponseDto.java
@@ -1,0 +1,33 @@
+package org.mjulikelion.bagel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ResponseDto<T> {
+    private final int statusCode;
+    private final String message;
+    private final T data;
+
+    public ResponseDto(final HttpStatus statusCode, final String resultMsg) {
+        this.statusCode = statusCode.value();
+        this.message = resultMsg;
+        this.data = null;
+    }
+
+    public static <T> ResponseDto<T> res(final HttpStatus statusCode, final String resultMsg) {
+        return res(statusCode, resultMsg, null);
+    }
+
+    public static <T> ResponseDto<T> res(final HttpStatus statusCode, final String resultMsg, final T t) {
+        return ResponseDto.<T>builder()
+                .data(t)
+                .statusCode(statusCode.value())
+                .message(resultMsg)
+                .build();
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/dto/response/application/ApplicationGetResponseData.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/response/application/ApplicationGetResponseData.java
@@ -1,0 +1,15 @@
+package org.mjulikelion.bagel.dto.response.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import org.mjulikelion.bagel.model.Agreement;
+import org.mjulikelion.bagel.model.Introduce;
+
+@Builder
+public class ApplicationGetResponseData {
+    @JsonProperty("introduces")
+    private List<Introduce> introduces;
+    @JsonProperty("agreements")
+    private List<Agreement> agreements;
+}

--- a/src/main/java/org/mjulikelion/bagel/model/Agreement.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Agreement.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,11 +35,14 @@ public class Agreement {
     private byte sequence;
 
     @CreatedDate
+    @JsonIgnore
     private Date createdAt;
 
     @LastModifiedDate
+    @JsonIgnore
     private Date updatedAt;
 
     @OneToMany(mappedBy = "agreement", orphanRemoval = true)
+    @JsonIgnore
     private List<ApplicationAgreement> applicationAgreement;
 }

--- a/src/main/java/org/mjulikelion/bagel/model/Introduce.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Introduce.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,5 +41,6 @@ public class Introduce {
     private Part part;
 
     @OneToMany(mappedBy = "introduce", orphanRemoval = true)
+    @JsonIgnore
     private List<ApplicationIntroduce> applicationIntroduce;
 }

--- a/src/main/java/org/mjulikelion/bagel/repository/IntroduceRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/IntroduceRepository.java
@@ -1,8 +1,11 @@
 package org.mjulikelion.bagel.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.mjulikelion.bagel.model.Introduce;
+import org.mjulikelion.bagel.model.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IntroduceRepository extends JpaRepository<Introduce, UUID> {
+    List<Introduce> findAllByPartOrderBySequence(Part part);
 }

--- a/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryService.java
+++ b/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryService.java
@@ -1,0 +1,10 @@
+package org.mjulikelion.bagel.service.application;
+
+import org.mjulikelion.bagel.dto.response.ResponseDto;
+import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
+import org.mjulikelion.bagel.model.Part;
+import org.springframework.http.ResponseEntity;
+
+public interface ApplicationQueryService {
+    ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(Part part);
+}

--- a/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryServiceImpl.java
+++ b/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package org.mjulikelion.bagel.service.application;
+
+import java.util.List;
+import org.mjulikelion.bagel.dto.response.ResponseDto;
+import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
+import org.mjulikelion.bagel.model.Agreement;
+import org.mjulikelion.bagel.model.Introduce;
+import org.mjulikelion.bagel.model.Part;
+import org.mjulikelion.bagel.repository.AgreementRepository;
+import org.mjulikelion.bagel.repository.IntroduceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplicationQueryServiceImpl implements ApplicationQueryService {
+    private final IntroduceRepository introduceRepository;
+    private final AgreementRepository agreementRepository;
+
+    @Autowired
+    public ApplicationQueryServiceImpl(IntroduceRepository introduceRepository,
+                                       AgreementRepository agreementRepository) {
+        this.introduceRepository = introduceRepository;
+        this.agreementRepository = agreementRepository;
+    }
+
+    @Override
+    public ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(Part part) {
+        List<Introduce> introduces = this.introduceRepository.findAllByPartOrderBySequence(
+                part);
+        List<Agreement> agreements = this.agreementRepository.findAll(
+                Sort.sort(Agreement.class).by(Agreement::getSequence));
+
+        ApplicationGetResponseData applicationGetResponse = ApplicationGetResponseData.builder()
+                .introduces(introduces)
+                .agreements(agreements)
+                .build();
+
+        return new ResponseEntity<>(ResponseDto.res(
+                HttpStatus.OK,
+                "Success",
+                applicationGetResponse
+        ), HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## Description
지원서 정보 API 개발
지원서에 필요한 정보 return
## Changes
### Introduce, Agreement Entity 수정
- [x] 반환 시 불필요한 데이터 @JsonIgnore 추가
### ApplicationController 개발
- [x] getApplicationByPart(Part part)
### ApplicationQueryService, ApplicationQueryServiceImpl 개발
- [x] getApplicationByPart(Part part)
### response Dto 개발
- [x] ResponseDto
- [x] ApplicationGetResponseData
### IntroduceRepository 메서드 추가
- [x] findAllByPartOrderBySequence(Part part) <- 해당 Part의 모든 Introduce를 찾은 후 Sequence 컬럼으로 정렬 후 반환
### API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /application/{part}          | GET  | 지원서      | X                    |
### Additional context
예외처리 적용 추후 예정, 예외처리 적용에 따라 코드의 변경이 있을 수 있음

Closes #5 