### PR TITLE
Feature/#10 DB id 컬럼 자료형 변경

### DIFF
--- a/src/main/java/org/mjulikelion/bagel/model/Agreement.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Agreement.java
@@ -3,13 +3,10 @@ package org.mjulikelion.bagel.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,8 +22,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 public class Agreement {
     @Id
     @Column(updatable = false, unique = true, nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-    private UUID id;
+    private String id;
 
     @Column(nullable = false, length = 100)
     private String content;

--- a/src/main/java/org/mjulikelion/bagel/model/Introduce.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Introduce.java
@@ -5,12 +5,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.List;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,8 +21,7 @@ import lombok.NoArgsConstructor;
 public class Introduce {
     @Id
     @Column(updatable = false, unique = true, nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-    private UUID id;
+    private String id;
 
     @Column(nullable = false, length = 100)
     private String title;

--- a/src/main/java/org/mjulikelion/bagel/model/Major.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Major.java
@@ -2,10 +2,7 @@ package org.mjulikelion.bagel.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,8 +14,7 @@ import lombok.NoArgsConstructor;
 public class Major {
     @Id
     @Column(updatable = false, unique = true, nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-    private UUID id;
+    private String id;
 
     @Column(name = "name", nullable = false, length = 100)
     private String name;

--- a/src/main/java/org/mjulikelion/bagel/model/Manager.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Manager.java
@@ -2,10 +2,7 @@ package org.mjulikelion.bagel.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,8 +16,7 @@ import lombok.NoArgsConstructor;
 public class Manager {
     @Id
     @Column(updatable = false, unique = true, nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
-    private UUID id;
+    private String id;
 
     @Column(nullable = false, length = 100)
     private String password;

--- a/src/main/java/org/mjulikelion/bagel/repository/AgreementRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/AgreementRepository.java
@@ -1,8 +1,7 @@
 package org.mjulikelion.bagel.repository;
 
-import java.util.UUID;
 import org.mjulikelion.bagel.model.Agreement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AgreementRepository extends JpaRepository<Agreement, UUID> {
+public interface AgreementRepository extends JpaRepository<Agreement, String> {
 }

--- a/src/main/java/org/mjulikelion/bagel/repository/IntroduceRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/IntroduceRepository.java
@@ -1,11 +1,10 @@
 package org.mjulikelion.bagel.repository;
 
 import java.util.List;
-import java.util.UUID;
 import org.mjulikelion.bagel.model.Introduce;
 import org.mjulikelion.bagel.model.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IntroduceRepository extends JpaRepository<Introduce, UUID> {
+public interface IntroduceRepository extends JpaRepository<Introduce, String> {
     List<Introduce> findAllByPartOrderBySequence(Part part);
 }

--- a/src/main/java/org/mjulikelion/bagel/repository/MajorRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/MajorRepository.java
@@ -1,8 +1,7 @@
 package org.mjulikelion.bagel.repository;
 
-import java.util.UUID;
 import org.mjulikelion.bagel.model.Major;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MajorRepository extends JpaRepository<Major, UUID> {
+public interface MajorRepository extends JpaRepository<Major, String> {
 }


### PR DESCRIPTION
## Description
DB id 컬럼 자료형 변경
Agreement, Introduce, Major, Manager 의 id 자료형을 UUID에서 String으로 변경
UUID 호환성 문제 때문
## Changes
### Agreement, Introduce, Major, Manager 의 id 자료형을 UUID에서 String으로 변경
- [x] Agreement
- [x] Introduce
- [x] Major
- [x] Manager 
### Agreement, Introduce, Major Repository 자료형 변경
- [x] AgreementRepository
- [x] IntroduceRepository
- [x] MajorRepository
## Additional context

Closes #10 