### PR TITLE
Feature/#27 지원하기 API 개발

### DIFF
--- a/src/main/java/org/mjulikelion/bagel/controller/ApplyController.java
+++ b/src/main/java/org/mjulikelion/bagel/controller/ApplyController.java
@@ -1,12 +1,17 @@
 package org.mjulikelion.bagel.controller;
 
+import jakarta.validation.Valid;
+import org.mjulikelion.bagel.dto.request.ApplySaveDto;
 import org.mjulikelion.bagel.dto.response.ResponseDto;
 import org.mjulikelion.bagel.dto.response.apply.ApplyExistResponseData;
+import org.mjulikelion.bagel.service.apply.ApplyCommandService;
 import org.mjulikelion.bagel.service.apply.ApplyQueryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,15 +19,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("apply")
 public class ApplyController {
     private final ApplyQueryService applicationQueryService;
+    private final ApplyCommandService applicationCommandService;
 
     @Autowired
-    public ApplyController(ApplyQueryService applicationQueryService) {
+    public ApplyController(ApplyQueryService applicationQueryService, ApplyCommandService applicationCommandService) {
         this.applicationQueryService = applicationQueryService;
+        this.applicationCommandService = applicationCommandService;
     }
 
     @GetMapping("/exist/{userId}")
     public ResponseEntity<ResponseDto<ApplyExistResponseData>> getApplicationExist(
             @PathVariable("userId") String userId) {
         return this.applicationQueryService.getApplyExist(userId);
+    }
+
+    @PostMapping()
+    public ResponseEntity<ResponseDto<Void>> saveApply(
+            @RequestBody @Valid ApplySaveDto applySaveDto) {
+        return this.applicationCommandService.saveApply(applySaveDto);
     }
 }

--- a/src/main/java/org/mjulikelion/bagel/dto/request/ApplySaveDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/request/ApplySaveDto.java
@@ -1,0 +1,16 @@
+package org.mjulikelion.bagel.dto.request;
+
+import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_USER_ID_PATTERN;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ApplySaveDto {
+    @JsonProperty
+    @NotNull
+    @Pattern(regexp = APPLICATION_USER_ID_PATTERN)
+    private String userId;
+}

--- a/src/main/java/org/mjulikelion/bagel/model/Application.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Application.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,7 @@ public class Application {
     private UUID id;
 
     @Column(name = "user_id", nullable = false, length = 100)
+    @NotNull
     private String userId;
 
     @Column(length = 100)

--- a/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandService.java
+++ b/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandService.java
@@ -1,0 +1,9 @@
+package org.mjulikelion.bagel.service.apply;
+
+import org.mjulikelion.bagel.dto.request.ApplySaveDto;
+import org.mjulikelion.bagel.dto.response.ResponseDto;
+import org.springframework.http.ResponseEntity;
+
+public interface ApplyCommandService {
+    ResponseEntity<ResponseDto<Void>> saveApply(ApplySaveDto applySaveDto);
+}

--- a/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandServiceImpl.java
+++ b/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandServiceImpl.java
@@ -1,0 +1,37 @@
+package org.mjulikelion.bagel.service.apply;
+
+import lombok.AllArgsConstructor;
+import org.mjulikelion.bagel.dto.request.ApplySaveDto;
+import org.mjulikelion.bagel.dto.response.ResponseDto;
+import org.mjulikelion.bagel.model.Application;
+import org.mjulikelion.bagel.repository.ApplicationRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class ApplyCommandServiceImpl implements ApplyCommandService {
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    @Transactional
+    public ResponseEntity<ResponseDto<Void>> saveApply(ApplySaveDto applySaveDto) {
+        if (this.applicationRepository.existsByUserId(applySaveDto.getUserId())) {
+            return new ResponseEntity<>(ResponseDto.res(
+                    HttpStatus.CONFLICT,
+                    "Already applied"
+            ), HttpStatus.CONFLICT);
+        }
+
+        Application application = Application.builder()
+                .userId(applySaveDto.getUserId())
+                .build();
+        this.applicationRepository.save(application);
+        return new ResponseEntity<>(ResponseDto.res(
+                HttpStatus.CREATED,
+                "Created"
+        ), HttpStatus.CREATED);
+    }
+}


### PR DESCRIPTION
## Description
지원하기 API 개발
userId를 통해 지원, userId는 Db에 저장
## Changes
### Application의 userId constraint 변경
- [x] userId에 not null 적용
### Dto 추가
- [x] ApplySaveDto
### ApplyController개발
- [x] createApply()
### ApplyCommandService, ApplyCommandServiceImpl 개발
- [x] createApply()
### API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /apply       | POST  | 지원하기| X                    |
### Additional context
해당 API 개발에 따라 지원서 제출 API에 예외처리 추가 필요
예외처리 적용 추후 예정, 예외처리 적용에 따라 코드의 변경이 있을 수 있음

Closes #27 