### PR TITLE
Feature/#34 지원하기에서 학번을 DB에 저장하게 됨에 따른 지원 방식, 지원서 제출 방식 대규모 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'//Lombok
     annotationProcessor 'org.projectlombok:lombok'//Lombok
     implementation 'org.springframework.boot:spring-boot-starter-validation'//Validation(Dto)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'//Redis
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/org/mjulikelion/bagel/BagelApplication.java
+++ b/src/main/java/org/mjulikelion/bagel/BagelApplication.java
@@ -2,12 +2,14 @@ package org.mjulikelion.bagel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BagelApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BagelApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BagelApplication.class, args);
+    }
 
 }

--- a/src/main/java/org/mjulikelion/bagel/config/RedisConfig.java
+++ b/src/main/java/org/mjulikelion/bagel/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package org.mjulikelion.bagel.config;
+
+import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, ApplicationGetResponseData> redisTemplateForApplicationGetResponseData(
+            RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, ApplicationGetResponseData> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(
+                new Jackson2JsonRedisSerializer<ApplicationGetResponseData>(ApplicationGetResponseData.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/constant/RegexPatterns.java
+++ b/src/main/java/org/mjulikelion/bagel/constant/RegexPatterns.java
@@ -1,7 +1,6 @@
 package org.mjulikelion.bagel.constant;
 
 public class RegexPatterns {
-    public static final String APPLICATION_USER_ID_PATTERN = "^[a-zA-Z][0-9a-zA-Z]{6,12}$";//영문자로 시작하고, 그 뒤로 숫자와 영문자의 조합이 6에서 12개까지인 문자열
     public static final String APPLICATION_NAME_PATTERN = "^[가-힣]{1,6}$";//1에서 6글자의 한글로 이루어진 문자열
     public static final String APPLICATION_STUDENT_ID_PATTERN = "^60\\d{6}$";//60으로 시작하고 그 뒤로 숫자 6개인 문자열
     public static final String APPLICATION_PHONE_NUMBER_PATTERN = "^010-\\d{4}-\\d{4}$";//010-숫자4개-숫자4개

--- a/src/main/java/org/mjulikelion/bagel/controller/ApplicationController.java
+++ b/src/main/java/org/mjulikelion/bagel/controller/ApplicationController.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import org.mjulikelion.bagel.dto.request.ApplicationSaveDto;
 import org.mjulikelion.bagel.dto.response.ResponseDto;
 import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
-import org.mjulikelion.bagel.model.Part;
 import org.mjulikelion.bagel.service.application.ApplicationCommandService;
 import org.mjulikelion.bagel.service.application.ApplicationQueryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,7 @@ public class ApplicationController {
 
     @GetMapping("/{part}")
     public ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(
-            @PathVariable("part") Part part) {
+            @PathVariable("part") String part) {
         return this.applicationQueryService.getApplicationByPart(part);
     }
 

--- a/src/main/java/org/mjulikelion/bagel/controller/ApplyController.java
+++ b/src/main/java/org/mjulikelion/bagel/controller/ApplyController.java
@@ -1,12 +1,12 @@
 package org.mjulikelion.bagel.controller;
 
 import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import org.mjulikelion.bagel.dto.request.ApplySaveDto;
 import org.mjulikelion.bagel.dto.response.ResponseDto;
 import org.mjulikelion.bagel.dto.response.apply.ApplyExistResponseData;
 import org.mjulikelion.bagel.service.apply.ApplyCommandService;
 import org.mjulikelion.bagel.service.apply.ApplyQueryService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,26 +16,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@AllArgsConstructor
 @RequestMapping("apply")
 public class ApplyController {
-    private final ApplyQueryService applicationQueryService;
-    private final ApplyCommandService applicationCommandService;
+    private final ApplyQueryService applyQueryService;
+    private final ApplyCommandService applyCommandService;
 
-    @Autowired
-    public ApplyController(ApplyQueryService applicationQueryService, ApplyCommandService applicationCommandService) {
-        this.applicationQueryService = applicationQueryService;
-        this.applicationCommandService = applicationCommandService;
-    }
-
-    @GetMapping("/exist/{userId}")
+    @GetMapping("/exist/{studentId}")
     public ResponseEntity<ResponseDto<ApplyExistResponseData>> getApplicationExist(
-            @PathVariable("userId") String userId) {
-        return this.applicationQueryService.getApplyExist(userId);
+            @PathVariable("studentId") String studentId) {
+        return this.applyQueryService.getApplyExist(studentId);
     }
 
     @PostMapping()
     public ResponseEntity<ResponseDto<Void>> saveApply(
             @RequestBody @Valid ApplySaveDto applySaveDto) {
-        return this.applicationCommandService.saveApply(applySaveDto);
+        return this.applyCommandService.saveApply(applySaveDto);
     }
 }

--- a/src/main/java/org/mjulikelion/bagel/dto/request/ApplicationSaveDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/request/ApplicationSaveDto.java
@@ -3,7 +3,6 @@ package org.mjulikelion.bagel.dto.request;
 import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_NAME_PATTERN;
 import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_PHONE_NUMBER_PATTERN;
 import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_STUDENT_ID_PATTERN;
-import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_USER_ID_PATTERN;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
@@ -21,22 +20,18 @@ import org.mjulikelion.bagel.util.annotaion.enumconstraint.EnumConstraint;
 @Getter
 public class ApplicationSaveDto {
     @NotNull
-    @Pattern(regexp = APPLICATION_USER_ID_PATTERN, message = "1")
-    private String userId;//지원 아이디
+    @Pattern(regexp = APPLICATION_STUDENT_ID_PATTERN)
+    private String studentId;//학번
 
     @NotNull
-    @Pattern(regexp = APPLICATION_NAME_PATTERN, message = "2")
+    @Pattern(regexp = APPLICATION_NAME_PATTERN)
     private String name;//이름
 
     @NotNull
     private String majorId;//학과 id
 
     @NotNull
-    @Pattern(regexp = APPLICATION_STUDENT_ID_PATTERN, message = "3")
-    private String studentId;//학번
-
-    @NotNull
-    @Pattern(regexp = APPLICATION_PHONE_NUMBER_PATTERN, message = "4")
+    @Pattern(regexp = APPLICATION_PHONE_NUMBER_PATTERN)
     private String phoneNumber;//전화번호
 
     @NotNull

--- a/src/main/java/org/mjulikelion/bagel/dto/request/ApplySaveDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/request/ApplySaveDto.java
@@ -1,6 +1,6 @@
 package org.mjulikelion.bagel.dto.request;
 
-import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_USER_ID_PATTERN;
+import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_STUDENT_ID_PATTERN;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -9,6 +9,6 @@ import lombok.Getter;
 @Getter
 public class ApplySaveDto {
     @NotNull
-    @Pattern(regexp = APPLICATION_USER_ID_PATTERN)
-    private String userId;
+    @Pattern(regexp = APPLICATION_STUDENT_ID_PATTERN)
+    private String studentId;//학번
 }

--- a/src/main/java/org/mjulikelion/bagel/dto/response/ResponseDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/response/ResponseDto.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,8 +10,11 @@ import org.springframework.http.HttpStatus;
 @Builder
 @AllArgsConstructor
 public class ResponseDto<T> {
+    @JsonProperty
     private final int statusCode;
+    @JsonProperty
     private final String message;
+    @JsonProperty
     private final T data;
 
     public ResponseDto(final HttpStatus statusCode, final String resultMsg) {

--- a/src/main/java/org/mjulikelion/bagel/dto/response/application/ApplicationGetResponseData.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/response/application/ApplicationGetResponseData.java
@@ -2,14 +2,21 @@ package org.mjulikelion.bagel.dto.response.application;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.mjulikelion.bagel.model.Agreement;
 import org.mjulikelion.bagel.model.Introduce;
+import org.mjulikelion.bagel.model.Major;
 
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ApplicationGetResponseData {
     @JsonProperty("introduces")
     private List<Introduce> introduces;
     @JsonProperty("agreements")
     private List<Agreement> agreements;
+    @JsonProperty("majors")
+    private List<Major> majors;
 }

--- a/src/main/java/org/mjulikelion/bagel/dto/response/apply/ApplyExistResponseData.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/response/apply/ApplyExistResponseData.java
@@ -1,8 +1,10 @@
 package org.mjulikelion.bagel.dto.response.apply;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 @Builder
 public class ApplyExistResponseData {
+    @JsonProperty
     private Boolean isExist;
 }

--- a/src/main/java/org/mjulikelion/bagel/model/Agreement.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Agreement.java
@@ -3,6 +3,7 @@ package org.mjulikelion.bagel.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.Date;
@@ -13,12 +14,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "agreement")
+@EntityListeners(AuditingEntityListener.class)
 public class Agreement {
     @Id
     @Column(updatable = false, unique = true, nullable = false)

--- a/src/main/java/org/mjulikelion/bagel/model/Application.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Application.java
@@ -11,15 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -30,10 +31,6 @@ public class Application {
     @Column(updatable = false, unique = true, nullable = false)
     private UUID id;
 
-    @Column(name = "user_id", nullable = false, length = 100)
-    @NotNull
-    private String userId;
-
     @Column(length = 100)
     private String name;
 
@@ -41,7 +38,7 @@ public class Application {
     @JoinColumn(name = "major_id")
     private Major major;
 
-    @Column(name = "student_id", length = 100)
+    @Column(name = "student_id", length = 8)
     private String studentId;
 
     @Column(length = 100)

--- a/src/main/java/org/mjulikelion/bagel/model/History.java
+++ b/src/main/java/org/mjulikelion/bagel/model/History.java
@@ -1,0 +1,35 @@
+package org.mjulikelion.bagel.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity(name = "history")
+public class History {
+    @Id
+    @Column(length = 8, updatable = false, unique = true, nullable = false)
+    @NotNull
+    private String studentId;
+
+    @CreatedDate
+    @Column(updatable = false)
+    @JsonIgnore
+    private Date createdAt;
+}

--- a/src/main/java/org/mjulikelion/bagel/model/Major.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Major.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -18,9 +19,13 @@ public class Major {
     @Column(updatable = false, unique = true, nullable = false)
     private String id;
 
-    @Column(name = "name", nullable = false, length = 100)
+    @Column(nullable = false, length = 100)
     private String name;
 
+    @Column(nullable = false)
+    private byte sequence;
+
     @OneToMany(mappedBy = "major")
+    @JsonIgnore
     private List<Application> applications;
 }

--- a/src/main/java/org/mjulikelion/bagel/model/Part.java
+++ b/src/main/java/org/mjulikelion/bagel/model/Part.java
@@ -1,5 +1,14 @@
 package org.mjulikelion.bagel.model;
 
 public enum Part {
-    SERVER, WEB
+    SERVER, WEB;
+
+    public static Part findBy(String part) {
+        for (Part p : Part.values()) {
+            if (p.name().equals(part)) {
+                return p;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/mjulikelion/bagel/repository/ApplicationRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/ApplicationRepository.java
@@ -5,5 +5,5 @@ import org.mjulikelion.bagel.model.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplicationRepository extends JpaRepository<Application, UUID> {
-    boolean existsByUserId(String userId);
+    boolean existsByStudentId(String userId);
 }

--- a/src/main/java/org/mjulikelion/bagel/repository/HistoryRepository.java
+++ b/src/main/java/org/mjulikelion/bagel/repository/HistoryRepository.java
@@ -1,0 +1,8 @@
+package org.mjulikelion.bagel.repository;
+
+import java.util.UUID;
+import org.mjulikelion.bagel.model.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, UUID> {
+}

--- a/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryService.java
+++ b/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryService.java
@@ -2,9 +2,8 @@ package org.mjulikelion.bagel.service.application;
 
 import org.mjulikelion.bagel.dto.response.ResponseDto;
 import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
-import org.mjulikelion.bagel.model.Part;
 import org.springframework.http.ResponseEntity;
 
 public interface ApplicationQueryService {
-    ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(Part part);
+    ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(String part);
 }

--- a/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryServiceImpl.java
+++ b/src/main/java/org/mjulikelion/bagel/service/application/ApplicationQueryServiceImpl.java
@@ -1,41 +1,114 @@
 package org.mjulikelion.bagel.service.application;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mjulikelion.bagel.dto.response.ResponseDto;
 import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
 import org.mjulikelion.bagel.model.Agreement;
 import org.mjulikelion.bagel.model.Introduce;
+import org.mjulikelion.bagel.model.Major;
 import org.mjulikelion.bagel.model.Part;
 import org.mjulikelion.bagel.repository.AgreementRepository;
 import org.mjulikelion.bagel.repository.IntroduceRepository;
-import org.springframework.data.domain.Sort;
+import org.mjulikelion.bagel.repository.MajorRepository;
+import org.mjulikelion.bagel.util.redis.ApplicationGetResponseDataRedisUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class ApplicationQueryServiceImpl implements ApplicationQueryService {
+
     private final IntroduceRepository introduceRepository;
     private final AgreementRepository agreementRepository;
+    private final MajorRepository majorRepository;
+    private final ApplicationGetResponseDataRedisUtil applicationGetResponseDataRedisUtil;
 
     @Override
-    public ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(Part part) {
-        List<Introduce> introduces = this.introduceRepository.findAllByPartOrderBySequence(
-                part);
-        List<Agreement> agreements = this.agreementRepository.findAll(
-                Sort.sort(Agreement.class).by(Agreement::getSequence));
+    public ResponseEntity<ResponseDto<ApplicationGetResponseData>> getApplicationByPart(String part) {
+        Part partEnum = Part.findBy(part.toUpperCase());
 
-        ApplicationGetResponseData applicationGetResponse = ApplicationGetResponseData.builder()
+        if (partEnum == null) {
+            return this.handleInvalidPart();
+        }
+
+        Optional<ApplicationGetResponseData> cachedResponse = this.getCachedApplicationGetResponseData(partEnum);
+
+        ApplicationGetResponseData response = cachedResponse.orElseGet(() -> {
+            ApplicationGetResponseData responseData = this.buildApplicationGetResponseData(partEnum);
+            this.cacheApplicationGetResponseData(partEnum, responseData);
+            return responseData;
+        });
+
+        return this.successResponse(response);
+    }
+
+    /**
+     * part가 유효하지 않은 경우의 ResponseEntity를 생성하여 반환.
+     *
+     * @return part가 유효하지 않은 경우의 ResponseEntity
+     */
+    private ResponseEntity<ResponseDto<ApplicationGetResponseData>> handleInvalidPart() {
+        return new ResponseEntity<>(ResponseDto.res(
+                HttpStatus.BAD_REQUEST,
+                "Invalid part"
+        ), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * ApplicationGetResponseData를 Redis에 캐싱한다.
+     *
+     * @param partEnum                   part
+     * @param applicationGetResponseData ApplicationGetResponseData
+     */
+    private void cacheApplicationGetResponseData(Part partEnum, ApplicationGetResponseData applicationGetResponseData) {
+        this.applicationGetResponseDataRedisUtil.setApplicationGetResponseData(partEnum.name(),
+                applicationGetResponseData);
+    }
+
+    /**
+     * Redis에서 ApplicationGetResponseData를 가져온다.
+     *
+     * @param partEnum part
+     * @return {@code Optional<ApplicationGetResponseData>}
+     */
+    private Optional<ApplicationGetResponseData> getCachedApplicationGetResponseData(Part partEnum) {
+        return Optional.ofNullable(applicationGetResponseDataRedisUtil.getApplicationGetResponseData(partEnum.name()));
+    }
+
+    /**
+     * ApplicationGetResponseData를 생성한다.
+     *
+     * @param partEnum part
+     * @return ApplicationGetResponseData
+     */
+    private ApplicationGetResponseData buildApplicationGetResponseData(Part partEnum) {
+        List<Introduce> introduces = introduceRepository.findAllByPartOrderBySequence(partEnum);
+        List<Agreement> agreements = agreementRepository.findAll();
+        List<Major> majors = majorRepository.findAll();
+
+        return ApplicationGetResponseData.builder()
                 .introduces(introduces)
                 .agreements(agreements)
+                .majors(majors)
                 .build();
+    }
 
+    /**
+     * 지원서 저장이 성공한 경우의 ResponseEntity를 생성하여 반환.
+     *
+     * @return 지원서 저장이 성공한 경우의 ResponseEntity
+     */
+    private ResponseEntity<ResponseDto<ApplicationGetResponseData>> successResponse(
+            ApplicationGetResponseData applicationGetResponseData) {
         return new ResponseEntity<>(ResponseDto.res(
                 HttpStatus.OK,
                 "Success",
-                applicationGetResponse
+                applicationGetResponseData
         ), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandServiceImpl.java
+++ b/src/main/java/org/mjulikelion/bagel/service/apply/ApplyCommandServiceImpl.java
@@ -3,8 +3,9 @@ package org.mjulikelion.bagel.service.apply;
 import lombok.AllArgsConstructor;
 import org.mjulikelion.bagel.dto.request.ApplySaveDto;
 import org.mjulikelion.bagel.dto.response.ResponseDto;
-import org.mjulikelion.bagel.model.Application;
+import org.mjulikelion.bagel.model.History;
 import org.mjulikelion.bagel.repository.ApplicationRepository;
+import org.mjulikelion.bagel.repository.HistoryRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -14,21 +15,24 @@ import org.springframework.transaction.annotation.Transactional;
 @AllArgsConstructor
 public class ApplyCommandServiceImpl implements ApplyCommandService {
     private final ApplicationRepository applicationRepository;
+    private final HistoryRepository historyRepository;
 
     @Override
     @Transactional
     public ResponseEntity<ResponseDto<Void>> saveApply(ApplySaveDto applySaveDto) {
-        if (this.applicationRepository.existsByUserId(applySaveDto.getUserId())) {
+        //이미 지원서가 있는지 확인
+        if (this.applicationRepository.existsByStudentId(applySaveDto.getStudentId())) {
             return new ResponseEntity<>(ResponseDto.res(
                     HttpStatus.CONFLICT,
                     "Already applied"
             ), HttpStatus.CONFLICT);
         }
 
-        Application application = Application.builder()
-                .userId(applySaveDto.getUserId())
+        History history = History.builder()
+                .studentId(applySaveDto.getStudentId())
                 .build();
-        this.applicationRepository.save(application);
+        this.historyRepository.save(history);
+
         return new ResponseEntity<>(ResponseDto.res(
                 HttpStatus.CREATED,
                 "Created"

--- a/src/main/java/org/mjulikelion/bagel/service/apply/ApplyQueryServiceImpl.java
+++ b/src/main/java/org/mjulikelion/bagel/service/apply/ApplyQueryServiceImpl.java
@@ -14,9 +14,9 @@ public class ApplyQueryServiceImpl implements ApplyQueryService {
     private final ApplicationRepository applicationRepository;
 
     @Override
-    public ResponseEntity<ResponseDto<ApplyExistResponseData>> getApplyExist(String userId) {
+    public ResponseEntity<ResponseDto<ApplyExistResponseData>> getApplyExist(String studentId) {
         ApplyExistResponseData applicationExistResponse = ApplyExistResponseData.builder()
-                .isExist(this.applicationRepository.existsByUserId(userId))
+                .isExist(this.applicationRepository.existsByStudentId(studentId))
                 .build();
         return new ResponseEntity<>(ResponseDto.res(
                 HttpStatus.OK,

--- a/src/main/java/org/mjulikelion/bagel/util/converter/ApplicationAgreementConverter.java
+++ b/src/main/java/org/mjulikelion/bagel/util/converter/ApplicationAgreementConverter.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.util.converter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -7,15 +8,15 @@ import lombok.AllArgsConstructor;
 import org.mjulikelion.bagel.model.Application;
 import org.mjulikelion.bagel.model.ApplicationAgreement;
 import org.mjulikelion.bagel.repository.AgreementRepository;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
-@Component
+@Service
 public class ApplicationAgreementConverter {
     private final AgreementRepository agreementRepository;
 
     /**
-     * Description: {@code Map<String, String>, Application -> List<ApplicationAgreement> 변환}
+     * {@code Map<String, String>, Application -> List<ApplicationAgreement> 변환}.
      *
      * @param agreementMap agreement 아이디, 동의 여부
      * @param application  application 객체
@@ -23,11 +24,27 @@ public class ApplicationAgreementConverter {
      */
     public List<ApplicationAgreement> convertMapToApplicationAgreement(Map<String, Boolean> agreementMap,
                                                                        Application application) {
-        return agreementMap.keySet().stream()
+        List<String> agreementIdList = new ArrayList<>(agreementMap.keySet());
+        if (!this.isValidAgreementMap(agreementIdList)) {
+            return null;
+        }
+
+        return agreementIdList.stream()
                 .map(agreementId -> ApplicationAgreement.builder()
-                        .agreement(agreementRepository.findById(agreementId).orElseThrow())
+                        .agreement(this.agreementRepository.findById(agreementId).orElseThrow())
                         .application(application)
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * agreementIdList가 유효한지 확인.
+     *
+     * @param agreementIdList agreement 아이디 리스트
+     * @return 유효하면 true, 아니면 false
+     */
+    private boolean isValidAgreementMap(List<String> agreementIdList) {
+        return agreementIdList.stream()
+                .allMatch(this.agreementRepository::existsById);
     }
 }

--- a/src/main/java/org/mjulikelion/bagel/util/converter/ApplicationIntroduceConverter.java
+++ b/src/main/java/org/mjulikelion/bagel/util/converter/ApplicationIntroduceConverter.java
@@ -1,5 +1,6 @@
 package org.mjulikelion.bagel.util.converter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -7,15 +8,15 @@ import lombok.AllArgsConstructor;
 import org.mjulikelion.bagel.model.Application;
 import org.mjulikelion.bagel.model.ApplicationIntroduce;
 import org.mjulikelion.bagel.repository.IntroduceRepository;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @AllArgsConstructor
-@Component
+@Service
 public class ApplicationIntroduceConverter {
     private final IntroduceRepository introduceRepository;
 
     /**
-     * Description: {@code Map<String, String>, Application -> List<ApplicationIntroduce> 변환}
+     * {@code Map<String, String>, Application -> List<ApplicationIntroduce> 변환}
      *
      * @param introduceMap introduce 아이디, introduce 내용
      * @param application  application 객체
@@ -23,12 +24,27 @@ public class ApplicationIntroduceConverter {
      */
     public List<ApplicationIntroduce> convertMapToApplicationIntroduce(Map<String, String> introduceMap,
                                                                        Application application) {
-        return introduceMap.keySet().stream()
+        List<String> introduceList = new ArrayList<>(introduceMap.keySet());
+        if (!this.isValidIntroduceMap(introduceList)) {
+            return null;
+        }
+        return introduceList.stream()
                 .map(introduce -> ApplicationIntroduce.builder()
                         .introduce(this.introduceRepository.findById(introduce).orElseThrow())
                         .content(introduceMap.get(introduce))
                         .application(application)
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * introduceList가 유효한지 확인
+     *
+     * @param introduceMap introduce 아이디 리스트
+     * @return 유효하면 true, 아니면 false
+     */
+    private boolean isValidIntroduceMap(List<String> introduceMap) {
+        return introduceMap.stream()
+                .allMatch(this.introduceRepository::existsById);
     }
 }

--- a/src/main/java/org/mjulikelion/bagel/util/redis/ApplicationGetResponseDataRedisUtil.java
+++ b/src/main/java/org/mjulikelion/bagel/util/redis/ApplicationGetResponseDataRedisUtil.java
@@ -1,0 +1,20 @@
+package org.mjulikelion.bagel.util.redis;
+
+import lombok.AllArgsConstructor;
+import org.mjulikelion.bagel.dto.response.application.ApplicationGetResponseData;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ApplicationGetResponseDataRedisUtil {
+    private final RedisTemplate<String, ApplicationGetResponseData> applicationGetResponseDataRedisTemplate;
+
+    public void setApplicationGetResponseData(String part, ApplicationGetResponseData applicationGetResponseData) {
+        this.applicationGetResponseDataRedisTemplate.opsForValue().set(part, applicationGetResponseData);
+    }
+
+    public ApplicationGetResponseData getApplicationGetResponseData(String part) {
+        return this.applicationGetResponseDataRedisTemplate.opsForValue().get(part);
+    }
+}


### PR DESCRIPTION
## Description
지원하기에서 학번을 DB에 저장하게 됨에 따른 지원 방식, 지원서 제출 방식 변경

1. 지원 시 학번을 받아 History 에 저장( 트래픽 측정 용도 테이블 )
2. Application의 userId 컬럼 삭제( 학번으로 식별하므로 )
3. 지원서 요청 api 캐싱(redis)
4. 지원서 요청 시 쿼리스트링 소문자 허용
5. 지원서 get 요청 시 전공 반환 추가
## Changes
### History 생성
- [x] History
- [x] HistoryRepository
### Dto 변경
- [x] ApplicationSaveDto
- [x] ApplySaveDto
- [x] ResponseDto
### ResponseData
- [x] ApplicationGetResponseData
- [x] ApplyExsistResponseData
### Controller
- [x] ApplicationController
- [x] ApplyController
### Service
- [x] ApplyQueryService
- [x] ApplyCommandService
- [x] ApplicationQueryService
- [x] ApplicationCommandService
### redis 설정
- [x] RedisConfig
- [x] ApplicationGetResponseDataRedisUtil
### API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /application        | POST| 지원서 제출| X                    |
| /application/{part}| GET| 지원서 정보| X                    |
| /apply/{studentId}| GET| 지원하기| X                    |
| /apply/{exist}| POST| 지원 여부| X                    |
## Additional context
예외처리 적용 추후 예정, 예외처리 적용에 따라 코드의 변경이 있을 수 있음

Closes #34 