### PR TITLE
Feature/#59 윈도우 환경에서 zip 파일을 인식하지 못하는 문제

### DIFF
--- a/src/main/java/org/mjulikelion/bagel/constant/FileConstant.java
+++ b/src/main/java/org/mjulikelion/bagel/constant/FileConstant.java
@@ -5,4 +5,5 @@ public class FileConstant {
     public static final int MB = 1024 * 1024;
     public static final int MAX_FILE_SIZE = MB * 10;
     public static final String ZIP_CONTENT_TYPE = "application/zip";
+    public static final String X_ZIP_CONTENT_TYPE = "application/x-zip-compressed";
 }

--- a/src/main/java/org/mjulikelion/bagel/util/annotaion/file/introduce/IntroduceFileConstraintValidator.java
+++ b/src/main/java/org/mjulikelion/bagel/util/annotaion/file/introduce/IntroduceFileConstraintValidator.java
@@ -1,6 +1,7 @@
 package org.mjulikelion.bagel.util.annotaion.file.introduce;
 
 import static org.mjulikelion.bagel.constant.FileConstant.MAX_FILE_SIZE;
+import static org.mjulikelion.bagel.constant.FileConstant.X_ZIP_CONTENT_TYPE;
 import static org.mjulikelion.bagel.constant.FileConstant.ZIP_CONTENT_TYPE;
 import static org.mjulikelion.bagel.constant.FileConstant.ZIP_EXTENSION;
 import static org.mjulikelion.bagel.constant.RegexPatterns.APPLICATION_STUDENT_ID_PATTERN;
@@ -39,12 +40,18 @@ public class IntroduceFileConstraintValidator implements ConstraintValidator<Int
     }
 
     private boolean isValidFileExtension(MultipartFile file) {
-        log.info("Is file extension valid? {}",
-                Objects.equals(file.getContentType(), ZIP_CONTENT_TYPE) && Objects.requireNonNull(
-                        file.getOriginalFilename()).toLowerCase().endsWith(ZIP_EXTENSION));
-        return Objects.equals(file.getContentType(), ZIP_CONTENT_TYPE) && Objects.requireNonNull(
-                file.getOriginalFilename()).toLowerCase().endsWith(ZIP_EXTENSION);
+        String contentType = file.getContentType();
+        String filename = file.getOriginalFilename();
+
+        boolean isValidContentType =
+                Objects.equals(contentType, ZIP_CONTENT_TYPE) || Objects.equals(contentType, X_ZIP_CONTENT_TYPE);
+        boolean isValidFileExtension = filename != null && filename.toLowerCase().endsWith(ZIP_EXTENSION);
+
+        log.info("Is file extension valid? {}", isValidContentType && isValidFileExtension);
+
+        return isValidContentType && isValidFileExtension;
     }
+
 
     private boolean isValidFileSize(MultipartFile file) {
         log.info("Is file size valid? {}", file.getSize() <= MAX_FILE_SIZE);


### PR DESCRIPTION
## Description
윈도우 환경에서 zip 파일을 인식하지 못하는 문제

file type의 차이
Mac: .zip 파일의 타입이 application/zip
Windows: .zip 파일의 타입이 application/x-zip-compressed
## Changes
### 조건문 추가
- [x] IntroduceFileConstraintValidator
### 정규식 추가
- [x] FileConstant
## Additional context
해결 확인을 위해 Issue를 연결하지 않음