### PR TITLE
Feature/#65 슬랙 연동 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'//Redis
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'//AWS
     implementation 'javax.xml.bind:jaxb-api:2.3.1'//JAXB
+    implementation("com.slack.api:bolt:1.18.0")//Slack
+    implementation("com.slack.api:bolt-servlet:1.18.0")//Slack
+    implementation("com.slack.api:bolt-jetty:1.18.0")//Slack
 
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/mjulikelion/bagel/util/slack/SlackService.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/SlackService.java
@@ -1,0 +1,37 @@
+package org.mjulikelion.bagel.util.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.mjulikelion.bagel.util.slack.asset.message.SlackMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class SlackService {
+    @Value(value = "${slack.token}")
+    String slackToken;
+
+    public void sendSlackMessage(SlackMessage slackMessage) {
+
+        String channelAddress = slackMessage.getChannel().getChannelName();
+
+        try {
+            MethodsClient methods = Slack.getInstance().methods(slackToken);
+
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(channelAddress)
+                    .text(slackMessage.getMessage())
+                    .build();
+
+            methods.chatPostMessage(request);
+
+        } catch (SlackApiException | IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/util/slack/asset/SlackChannel.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/asset/SlackChannel.java
@@ -1,0 +1,15 @@
+package org.mjulikelion.bagel.util.slack.asset;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SlackChannel {
+    FILE("#12기-지원-테스트-파일", "--- 파일이 업로드 되었습니다 ---"),
+    APPLICATION("#12기-지원-테스트-지원서", "--- 지원서가 업로드 되었습니다 ---"),
+    APPLY("#12기-지원-테스트-지원", "--- 새 지원 요청이 있습니다 ---");
+
+    private final String channelName;
+    private final String messageTitle;
+}

--- a/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackApplyMessage.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackApplyMessage.java
@@ -1,0 +1,10 @@
+package org.mjulikelion.bagel.util.slack.asset.message;
+
+import org.mjulikelion.bagel.util.slack.asset.SlackChannel;
+
+
+public class SlackApplyMessage extends SlackMessage {
+    public SlackApplyMessage(String studentId) {
+        super(SlackChannel.APPLY, String.format("%s\n\n학번: %s", SlackChannel.APPLY.getMessageTitle(), studentId));
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackApplySaveMessage.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackApplySaveMessage.java
@@ -1,0 +1,13 @@
+package org.mjulikelion.bagel.util.slack.asset.message;
+
+import org.mjulikelion.bagel.model.Application;
+import org.mjulikelion.bagel.util.slack.asset.SlackChannel;
+
+public class SlackApplySaveMessage extends SlackMessage {
+    public SlackApplySaveMessage(Application application) {
+        super(SlackChannel.APPLICATION, String.format("%s\n\n이름: %s\n학과: %s\n학번: %s\n학년: %s\n전화번호: %s\n이메일: %s\n파트: %s",
+                SlackChannel.APPLICATION.getMessageTitle(), application.getName(), application.getMajor().getName(),
+                application.getStudentId(), application.getGrade(), application.getPhoneNumber(),
+                application.getEmail(), application.getPart()));
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackFileMessage.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackFileMessage.java
@@ -1,0 +1,10 @@
+package org.mjulikelion.bagel.util.slack.asset.message;
+
+import org.mjulikelion.bagel.util.slack.asset.SlackChannel;
+
+public class SlackFileMessage extends SlackMessage {
+    public SlackFileMessage(String fileName, String fileUrl) {
+        super(SlackChannel.FILE, String.format("%s\n\n업로드 요청 파일명: %s\n파일 url: %s",
+                SlackChannel.FILE.getMessageTitle(), fileName, fileUrl));
+    }
+}

--- a/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackMessage.java
+++ b/src/main/java/org/mjulikelion/bagel/util/slack/asset/message/SlackMessage.java
@@ -1,0 +1,20 @@
+package org.mjulikelion.bagel.util.slack.asset.message;
+
+import lombok.Getter;
+import org.joda.time.DateTime;
+import org.mjulikelion.bagel.util.slack.asset.SlackChannel;
+
+@Getter
+public class SlackMessage {
+    protected SlackChannel channel;
+    protected String message;
+
+    public SlackMessage(SlackChannel channel, String message) {
+        this.channel = channel;
+        this.message = message + "\n\n요청 일시: " + buildTimestamp();
+    }
+
+    protected String buildTimestamp() {
+        return new DateTime().toString("yyyy-MM-dd HH:mm:ss");
+    }
+}


### PR DESCRIPTION
## Description
슬랙 연동 작업
## Changes
### 의존성 추가 
- [x] implementation("com.slack.api:bolt:1.18.0")
- [x] implementation("com.slack.api:bolt-servlet:1.18.0")
- [x] implementation("com.slack.api:bolt-jetty:1.18.0")
### SlackService
- [x] SlackService
### SlackMessage
- [x] SlackMessage
- [x] SlackApplyMessage
- [x] SlackApplySaveMessage
- [x] SlackFileMessage
### SlackChannel
- [x] SlackChannel
### 다른 Service에서 SlackService 사용
- [x] ApplicationCommandServiceImpl
- [x] ApplyCommandServiceImpl
## Additional context

Closes #65 