### PR TITLE
Feature/#83 email, link에 최대 길이 제한 설정

### DIFF
--- a/src/main/java/org/mjulikelion/bagel/dto/request/ApplicationSaveDto.java
+++ b/src/main/java/org/mjulikelion/bagel/dto/request/ApplicationSaveDto.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.Map;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 import org.mjulikelion.bagel.model.Part;
 import org.mjulikelion.bagel.util.annotaion.enumconstraint.EnumConstraint;
 import org.mjulikelion.bagel.util.annotaion.grade.GradeConstraint;
@@ -36,6 +37,7 @@ public class ApplicationSaveDto {
 
     @NotNull(message = "이메일이 누락되었습니다.")
     @Pattern(regexp = APPLICATION_EMAIL_PATTERN, message = "이메일이 형식에 맞지 않습니다.")
+    @Length(max = 100, message = "이메일은 100자를 넘을 수 없습니다.")
     private String email;//이메일
 
     @NotNull(message = "학년이 누락되었습니다.")
@@ -48,6 +50,7 @@ public class ApplicationSaveDto {
 
     @NotBlank(message = "자기소개 페이지 혹은 GitHub 링크가 누락되었습니다.")
     @Pattern(regexp = APPLICATION_LINK_PATTERN, message = "자기소개 페이지 혹은 GitHub 링크가 형식에 맞지 않습니다.")
+    @Length(max = 255, message = "자기소개 페이지 혹은 GitHub 링크는 255자를 넘을 수 없습니다.")
     private String link;//자기소개 페이지 or GitHub 링크
 
     @NotNull(message = "자기소개가 누락되었습니다.")

--- a/src/main/java/org/mjulikelion/bagel/errorcode/ValidationErrorCode.java
+++ b/src/main/java/org/mjulikelion/bagel/errorcode/ValidationErrorCode.java
@@ -12,7 +12,8 @@ public enum ValidationErrorCode {
     REGEX("9003", "형식에 맞지 않습니다."),
     ENUM_CONSTRAINT("9004", "유효하지 않은 Enum 값입니다."),
     GRADE_CONSTRAINT("9005", "학년이 형식에 맞지 않습니다."),
-    AGREEMENT_ASSERT_TRUE("9006", "동의가 필요합니다.");
+    AGREEMENT_ASSERT_TRUE("9006", "동의가 필요합니다."),
+    LENGTH("9007", "길이가 유효하지 않습니다.");
 
 
     private final String code;
@@ -27,6 +28,7 @@ public enum ValidationErrorCode {
             case "EnumConstraint" -> ENUM_CONSTRAINT;
             case "GradeConstraint" -> GRADE_CONSTRAINT;
             case "AssertTrue" -> AGREEMENT_ASSERT_TRUE;
+            case "Length" -> LENGTH;
             default -> throw new IllegalArgumentException("Unexpected value: " + code);
         };
     }


### PR DESCRIPTION
## Description
email, link에 최대 길이 제한 설정
## Changes
### @Length 어노테이션 추가
- [x] ApplicationSaveDto
### ValidationErrorCode에 Length 추가
- [x] ValidationErrorCode
## Additional context

이메일 100자
링크 255자

Closes #83 